### PR TITLE
修复笔误

### DIFF
--- a/ks_fruit.js
+++ b/ks_fruit.js
@@ -2,7 +2,7 @@
 v1.9
 快手果园任务脚本,支持qx,loon,shadowrocket,surge,nodejs
 手机设备在boxjs里填写cookie
-开启抓包工具,果园浇一次水,在抓包记录里搜water,复制请求头里的cookie,关键参数:client_key=xxxx;did==xxx;kuaishou.api_st=xxxx;ver=xxx;ud=xxxxx
+开启抓包工具,果园浇一次水,在抓包记录里搜water,复制请求头里的cookie,关键参数:client_key=xxxx;did=xxx;kuaishou.api_st=xxxx;ver=xxx;ud=xxxxx
 boxjs订阅地址:https://gitee.com/passerby-b/javascript/raw/master/JD/passerby-b.boxjs.json
 
 [task_local]


### PR DESCRIPTION
参数模板多一个“=”，导致直接套用时不能读取ck